### PR TITLE
DTA2-35: Add DecompressedFrameDelegate and wire in to sw and hw processor

### DIFF
--- a/Sample Code/ObjcSampleCode/DJISdkDemo/Demo/DemoUtility/DemoComponentHelper.h
+++ b/Sample Code/ObjcSampleCode/DJISdkDemo/Demo/DemoUtility/DemoComponentHelper.h
@@ -6,7 +6,10 @@
 //
 
 #import <Foundation/Foundation.h>
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdocumentation"
 #import <DJISDK/DJISDK.h>
+#pragma clang diagnostic pop
 
 @class DJIBaseProduct;
 @class DJIAircraft;

--- a/Sample Code/ObjcSampleCode/DJISdkDemo/Demo/DemoUtility/DemoComponentHelper.m
+++ b/Sample Code/ObjcSampleCode/DJISdkDemo/Demo/DemoUtility/DemoComponentHelper.m
@@ -8,8 +8,11 @@
  *  It is recommended that user should not cache any instances of DJIBaseProduct (including DJIAircraft and DJIHandheld) and any instances
  *  of DJIBaseComponent (e.g. DJICamera). Therefore, a set of helper methods is provided to access the product and components.
  */
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdocumentation"
 #import <DJISDK/DJISDK.h>
 #import "DemoComponentHelper.h"
+#pragma clang diagnostic pop
 
 @implementation DemoComponentHelper
 

--- a/Sample Code/ObjcSampleCode/DJISdkDemo/VideoPreviewerAdapter/VideoPreviewerSDKAdapter+Lightbridge2.m
+++ b/Sample Code/ObjcSampleCode/DJISdkDemo/VideoPreviewerAdapter/VideoPreviewerSDKAdapter+Lightbridge2.m
@@ -7,9 +7,12 @@
 
 #import "VideoPreviewerSDKAdapter+Lightbridge2.h"
 #import "DemoUtilityMacro.h"
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdocumentation"
 #import <DJISDK/DJISDK.h>
 #import <VideoPreviewer/VideoPreviewer.h>
 #import "DemoComponentHelper.h"
+#pragma clang diagnostic pop
 
 #define IS_FLOAT_EQUAL(a, b) (fabs(a - b) < 0.0005)
 

--- a/Sample Code/ObjcSampleCode/DJISdkDemo/VideoPreviewerAdapter/VideoPreviewerSDKAdapter.h
+++ b/Sample Code/ObjcSampleCode/DJISdkDemo/VideoPreviewerAdapter/VideoPreviewerSDKAdapter.h
@@ -6,7 +6,10 @@
 //
 
 #import <Foundation/Foundation.h>
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdocumentation"
 #import <DJISDK/DJISDK.h>
+#pragma clang diagnostic pop
 
 @class VideoPreviewer;
 

--- a/Sample Code/ObjcSampleCode/DJISdkDemo/VideoPreviewerAdapter/VideoPreviewerSDKAdapter.h
+++ b/Sample Code/ObjcSampleCode/DJISdkDemo/VideoPreviewerAdapter/VideoPreviewerSDKAdapter.h
@@ -15,15 +15,15 @@
 
 @interface VideoPreviewerSDKAdapter : NSObject <DJIVideoFeedSourceListener, DJIVideoFeedListener>
 
-+(instancetype)adapterWithDefaultSettings;
++(instancetype _Nonnull )adapterWithDefaultSettings;
 
-+(instancetype)adapterWithForLightbridge2; 
++(instancetype _Nonnull )adapterWithForLightbridge2; 
 
-+(instancetype)adapterWithVideoPreviewer:(VideoPreviewer *)videoPreviewer andVideoFeed:(DJIVideoFeed *)videoFeed;
++(instancetype _Nonnull )adapterWithVideoPreviewer:(VideoPreviewer *_Nullable)videoPreviewer andVideoFeed:(DJIVideoFeed *_Nullable)videoFeed;
 
-@property (nonatomic, weak) VideoPreviewer *videoPreviewer;
+@property (nonatomic, weak) VideoPreviewer * _Nullable videoPreviewer;
 
-@property (nonatomic, weak) DJIVideoFeed *videoFeed;
+@property (nonatomic, weak) DJIVideoFeed * _Nullable videoFeed;
 
 -(void)start;
 

--- a/Sample Code/ObjcSampleCode/DJISdkDemo/VideoPreviewerAdapter/VideoPreviewerSDKAdapter.m
+++ b/Sample Code/ObjcSampleCode/DJISdkDemo/VideoPreviewerAdapter/VideoPreviewerSDKAdapter.m
@@ -4,12 +4,14 @@
 //
 //  Copyright © 2016 DJI. All rights reserved.
 //
-
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdocumentation"
 #import "VideoPreviewerSDKAdapter.h"
 #import "VideoPreviewerSDKAdapter+Lightbridge2.h"
 #import <VideoPreviewer/VideoPreviewer.h>
 
 #import <DJISDK/DJISDK.h>
+#pragma clang diagnostic pop
 
 #define weakSelf(__TARGET__) __weak typeof(self) __TARGET__=self
 #define weakReturn(__TARGET__) if(__TARGET__==nil)return;
@@ -368,6 +370,7 @@ const static NSTimeInterval REFRESH_INTERVAL = 1.0;
 
 #pragma mark video delegate
 -(void)videoFeed:(DJIVideoFeed *)videoFeed didUpdateVideoData:(NSData *)videoData {
+
     if (videoFeed != self.videoFeed) {
         NSLog(@"ERROR: Wrong video feed update is received!");
     }

--- a/Sample Code/ObjcSampleCode/DJISdkDemo/VideoPreviewerAdapter/VideoPreviewerSDKAdapter.m
+++ b/Sample Code/ObjcSampleCode/DJISdkDemo/VideoPreviewerAdapter/VideoPreviewerSDKAdapter.m
@@ -164,10 +164,10 @@ const static NSTimeInterval REFRESH_INTERVAL = 1.0;
         [camera getOrientationWithCompletion:^(DJICameraOrientation orientation, NSError * _Nullable error) {
             if (error == nil) {
                 if (orientation == DJICameraOrientationLandscape) {
-                    [VideoPreviewer instance].rotation = VideoStreamRotationDefault;
+                    self.videoPreviewer.rotation = VideoStreamRotationDefault;
                 }
                 else {
-                    [VideoPreviewer instance].rotation = VideoStreamRotationCW90;
+                    self.videoPreviewer.rotation = VideoStreamRotationCW90;
                 }
             }
         }];

--- a/Sample Code/VideoPreviewer/VideoPreviewer/DJIStreamCommon.h
+++ b/Sample Code/VideoPreviewer/VideoPreviewer/DJIStreamCommon.h
@@ -199,3 +199,8 @@ typedef NS_ENUM(NSUInteger, VideoPresentContentMode){
 -(void) videoProcessFrame:(VideoFrameYUV*)frame;
 -(void) videoProcessFailedFrame;
 @end
+
+@protocol DecompressedFrameDelegate <NSObject>
+@required
+- (void)didReceiveDecompressedFrame:(CVImageBufferRef)image;
+@end

--- a/Sample Code/VideoPreviewer/VideoPreviewer/SoftwareDecodeProcessor.h
+++ b/Sample Code/VideoPreviewer/VideoPreviewer/SoftwareDecodeProcessor.h
@@ -12,5 +12,9 @@
 @property (nonatomic, weak) id<VideoFrameProcessor> frameProcessor;
 @property (nonatomic, assign) BOOL enabled;
 
+// -----------------------Cape added-----------------------
+@property (nonatomic, weak) id<DecompressedFrameDelegate> delegate;
+// --------------------------------------------------------
+
 -(id) initWithExtractor:(VideoFrameExtractor*)extractor;
 @end

--- a/Sample Code/VideoPreviewer/VideoPreviewer/SoftwareDecodeProcessor.m
+++ b/Sample Code/VideoPreviewer/VideoPreviewer/SoftwareDecodeProcessor.m
@@ -61,7 +61,17 @@
             [weakself.frameProcessor videoProcessFrame:_renderYUVFrame[_decodeFrameIndex]];
             
             _decodeFrameIndex = (++_decodeFrameIndex)%RENDER_FRAME_NUMBER;
-            
+
+            // -----------------------Cape added-----------------------
+            CVImageBufferRef image = [weakself.extractor getCVImage];
+            if (image) {
+                if (self.delegate) {
+                    [self.delegate didReceiveDecompressedFrame:image];
+                }
+            }
+            CFRelease(image); // Takes care of memory leak.
+            // --------------------------------------------------------
+
         }else{
             decodeSuccess = NO;
         }

--- a/Sample Code/VideoPreviewer/VideoPreviewer/VideoPreviewer.h
+++ b/Sample Code/VideoPreviewer/VideoPreviewer/VideoPreviewer.h
@@ -10,6 +10,8 @@
 #import "VideoFrameExtractor.h"
 #import "MovieGLView.h"
 #import "H264VTDecode.h"
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdocumentation"
 #import "DJIVideoHelper.h"
 #import "SoftwareDecodeProcessor.h"
 #import "VideoPreviewerQueue.h"
@@ -17,6 +19,7 @@
 #import "DJIVideoPresentViewAdjustHelper.h"
 #import "DJIVTH264DecoderIFrameData.h"
 #import "DJIRTPlayerRenderView.h"
+#pragma clang diagnostic pop
 
 #define __WAIT_STEP_FRAME__   (0) //单步调试用，搭配test_queue_pull
 
@@ -349,5 +352,9 @@ typedef NS_ENUM(NSUInteger, VideoPreviewerType){
  * @default 0
  */
 @property(readwrite, nonatomic) CGFloat highlightsDecrease;
+
+// -----------------------Cape added-----------------------
+@property(weak, nonatomic) id<DecompressedFrameDelegate> delegate;
+// -----------------------Cape added-----------------------
 
 @end

--- a/Sample Code/VideoPreviewer/VideoPreviewer/VideoPreviewer.m
+++ b/Sample Code/VideoPreviewer/VideoPreviewer/VideoPreviewer.m
@@ -1060,7 +1060,14 @@ LB2AUDHackParserDelegate>{
             CGSize size = CVImageBufferGetDisplaySize(image);
             if(kCVReturnSuccess != CVPixelBufferLockBaseAddress(image, 0))
                 return;
-            
+
+            // -----------------------Cape added-----------------------
+            // With updated video previewer, this else case is now called.
+            if (self.delegate) {
+                [self.delegate didReceiveDecompressedFrame:image]; // Causes crash in webRTC with XT. Works with X3 but super janky video.
+            }
+            // --------------------------------------------------------
+
             VideoFrameYUV yuvImage = {0};
             yuvImage.luma = CVPixelBufferGetBaseAddressOfPlane(image, 0);
             yuvImage.chromaB = CVPixelBufferGetBaseAddressOfPlane(image, 1);
@@ -1089,6 +1096,13 @@ LB2AUDHackParserDelegate>{
                  CGSize size = CVImageBufferGetDisplaySize(image);
                  if(kCVReturnSuccess != CVPixelBufferLockBaseAddress(image, 0))
                      return;
+
+                 // -----------------------Cape added-----------------------
+                 // With updated video previewer, this else case is now called.
+                 if (self.delegate) {
+                     [self.delegate didReceiveDecompressedFrame:image]; // Causes crash in webRTC with XT. Works with X3 but super janky video.
+                 }
+                 // --------------------------------------------------------
 
                  VideoFrameYUV yuvImage = {0};
                  yuvImage.luma = CVPixelBufferGetBaseAddressOfPlane(image, 0);
@@ -1340,5 +1354,13 @@ static NSThread* g_pack_pull_test_thread;
         }
     }
 }
+
+// -----------------------Cape added-----------------------
+-(void) setDelegate:(id<DecompressedFrameDelegate>)delegate
+{
+    _delegate = delegate;
+    self.soft_decoder.delegate = delegate;
+}
+// --------------------------------------------------------
 
 @end

--- a/Sample Code/VideoPreviewer/VideoPreviewer/VideoPreviewer.m
+++ b/Sample Code/VideoPreviewer/VideoPreviewer/VideoPreviewer.m
@@ -1062,10 +1062,7 @@ LB2AUDHackParserDelegate>{
                 return;
 
             // -----------------------Cape added-----------------------
-            // With updated video previewer, this else case is now called.
-            if (self.delegate) {
-                [self.delegate didReceiveDecompressedFrame:image]; // Causes crash in webRTC with XT. Works with X3 but super janky video.
-            }
+            [self.delegate didReceiveDecompressedFrame:image];
             // --------------------------------------------------------
 
             VideoFrameYUV yuvImage = {0};
@@ -1098,10 +1095,8 @@ LB2AUDHackParserDelegate>{
                      return;
 
                  // -----------------------Cape added-----------------------
-                 // With updated video previewer, this else case is now called.
-                 if (self.delegate) {
-                     [self.delegate didReceiveDecompressedFrame:image]; // Causes crash in webRTC with XT. Works with X3 but super janky video.
-                 }
+                 // FIXME: Causes crash in webRTC with XT. Works with X3 but super janky video.
+                 [self.delegate didReceiveDecompressedFrame:image];
                  // --------------------------------------------------------
 
                  VideoFrameYUV yuvImage = {0};


### PR DESCRIPTION
This represents the basic mods to VideoPreviewer that we need to hook into DT App V2.
(It also has a few pragmas to turn off annoying compiler warnings).