### PR TITLE
Adds logging hooks to VideoPreviewer

### DIFF
--- a/Sample Code/VideoPreviewer/VideoPreviewer.xcodeproj/project.pbxproj
+++ b/Sample Code/VideoPreviewer/VideoPreviewer.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		02EE504A1C3D9BC3006783E5 /* CoreMedia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 02EE50491C3D9BC3006783E5 /* CoreMedia.framework */; };
 		02EE504C1C3D9F36006783E5 /* VideoToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 02EE504B1C3D9F36006783E5 /* VideoToolbox.framework */; };
 		02EE50651C3DA525006783E5 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 02EE50641C3DA525006783E5 /* libz.tbd */; };
+		1D69F553201ABEBC00DDDA90 /* VideoPreviewerLogging.m in Sources */ = {isa = PBXBuildFile; fileRef = 1D69F552201ABEBC00DDDA90 /* VideoPreviewerLogging.m */; };
+		1D69F555201ABEDB00DDDA90 /* VideoPreviewerLogging.h in Headers */ = {isa = PBXBuildFile; fileRef = 1D69F554201ABEDB00DDDA90 /* VideoPreviewerLogging.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9AB30C041E64038E00107706 /* VideoPreviewer.m in Sources */ = {isa = PBXBuildFile; fileRef = 9AB30C021E64038E00107706 /* VideoPreviewer.m */; };
 		9AB30C051E64038E00107706 /* VideoPreviewer.h in Headers */ = {isa = PBXBuildFile; fileRef = 9AB30C031E64038E00107706 /* VideoPreviewer.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9AC273611E54473800DFBE85 /* DJIRTPlayerRenderView.h in Headers */ = {isa = PBXBuildFile; fileRef = 9AC2735D1E54473800DFBE85 /* DJIRTPlayerRenderView.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -188,6 +190,8 @@
 		02EE50491C3D9BC3006783E5 /* CoreMedia.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreMedia.framework; path = System/Library/Frameworks/CoreMedia.framework; sourceTree = SDKROOT; };
 		02EE504B1C3D9F36006783E5 /* VideoToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = VideoToolbox.framework; path = System/Library/Frameworks/VideoToolbox.framework; sourceTree = SDKROOT; };
 		02EE50641C3DA525006783E5 /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
+		1D69F552201ABEBC00DDDA90 /* VideoPreviewerLogging.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = VideoPreviewerLogging.m; path = VideoPreviewer/VideoPreviewerLogging.m; sourceTree = "<group>"; };
+		1D69F554201ABEDB00DDDA90 /* VideoPreviewerLogging.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = VideoPreviewerLogging.h; path = VideoPreviewer/VideoPreviewerLogging.h; sourceTree = "<group>"; };
 		9AB30C021E64038E00107706 /* VideoPreviewer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = VideoPreviewer.m; path = VideoPreviewer/VideoPreviewer.m; sourceTree = "<group>"; };
 		9AB30C031E64038E00107706 /* VideoPreviewer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = VideoPreviewer.h; path = VideoPreviewer/VideoPreviewer.h; sourceTree = "<group>"; };
 		9AC2735D1E54473800DFBE85 /* DJIRTPlayerRenderView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DJIRTPlayerRenderView.h; sourceTree = "<group>"; };
@@ -408,6 +412,8 @@
 				02EE4FD51C3D9B55006783E5 /* VideoFrameExtractor.h */,
 				02EE4FD61C3D9B55006783E5 /* VideoFrameExtractor.m */,
 				B83DC24B1D8FB298003461D3 /* VideoPreviewerMacros.h */,
+				1D69F554201ABEDB00DDDA90 /* VideoPreviewerLogging.h */,
+				1D69F552201ABEBC00DDDA90 /* VideoPreviewerLogging.m */,
 				9AB30C031E64038E00107706 /* VideoPreviewer.h */,
 				9AB30C021E64038E00107706 /* VideoPreviewer.m */,
 				02EE4FD21C3D9B55006783E5 /* Info.plist */,
@@ -822,6 +828,7 @@
 				9AC2747B1E544E7700DFBE85 /* DJIVideoPresentViewAdjustHelper.h in Headers */,
 				9AC274281E544E7700DFBE85 /* buffersink.h in Headers */,
 				9AC274231E544E7700DFBE85 /* version.h in Headers */,
+				1D69F555201ABEDB00DDDA90 /* VideoPreviewerLogging.h in Headers */,
 				9AC2749B1E544E7700DFBE85 /* DJILiveViewRenderTexture.h in Headers */,
 				9AC2744C1E544E7700DFBE85 /* hash.h in Headers */,
 				9AC274491E544E7700DFBE85 /* fifo.h in Headers */,
@@ -1028,6 +1035,7 @@
 				02EE50441C3D9B5B006783E5 /* MovieGLView.m in Sources */,
 				B82355351FA8C64500500A27 /* LB2AUDRemoveParser.m in Sources */,
 				9AC273691E5448AE00DFBE85 /* DJIRTPlayerRenderView.m in Sources */,
+				1D69F553201ABEBC00DDDA90 /* VideoPreviewerLogging.m in Sources */,
 				9AC2748A1E544E7700DFBE85 /* DJILiveViewRenderProgram.m in Sources */,
 				9AC2749A1E544E7700DFBE85 /* DJILiveViewRenderFocusWarningFilter.m in Sources */,
 				B82893321C9867AB00CCBD3B /* VideoPreviewerQueue.m in Sources */,

--- a/Sample Code/VideoPreviewer/VideoPreviewer/DJIVideoHelper.m
+++ b/Sample Code/VideoPreviewer/VideoPreviewer/DJIVideoHelper.m
@@ -5,9 +5,8 @@
 //
 
 #import "DJIVideoHelper.h"
-
-#define INFO(fmt, ...) //NSLog(fmt, ##__VA_ARGS__)
-#define ERROR(fmt, ...) //NSLog(fmt, ##__VA_ARGS__)
+#import "VideoPreviewer.h"
+#import "VideoPreviewerMacros.h"
 
 loadPrebuildIframeOverridePtr g_loadPrebuildIframeOverrideFunc = nil;
 loadPrebuildIframePathPtr g_loadPrebuildIframePathFunc = nil;

--- a/Sample Code/VideoPreviewer/VideoPreviewer/DJIVideoHelper.m
+++ b/Sample Code/VideoPreviewer/VideoPreviewer/DJIVideoHelper.m
@@ -5,8 +5,7 @@
 //
 
 #import "DJIVideoHelper.h"
-#import "VideoPreviewer.h"
-#import "VideoPreviewerMacros.h"
+#import "VideoPreviewerLogging.h"
 
 loadPrebuildIframeOverridePtr g_loadPrebuildIframeOverrideFunc = nil;
 loadPrebuildIframePathPtr g_loadPrebuildIframePathFunc = nil;

--- a/Sample Code/VideoPreviewer/VideoPreviewer/H264VTDecode.m
+++ b/Sample Code/VideoPreviewer/VideoPreviewer/H264VTDecode.m
@@ -7,10 +7,8 @@
 #import <UIKit/UIKit.h>
 #import "H264VTDecode.h"
 #import "DJIVideoHelper.h"
-//#import "DJILogCenter.h"
-
-#define INFO(fmt, ...) //DJILog(@"[VTDecoder]"fmt, ##__VA_ARGS__)
-#define ERROR(fmt, ...) //DJILog(@"[VTDecoder]"fmt, ##__VA_ARGS__)
+#import "VideoPreviewer.h"
+#import "VideoPreviewerMacros.h"
 
 #define DEFAULT_STREAM_FPS (30)
 #define FRAME_MAX_SLICE_COUNT (30)

--- a/Sample Code/VideoPreviewer/VideoPreviewer/H264VTDecode.m
+++ b/Sample Code/VideoPreviewer/VideoPreviewer/H264VTDecode.m
@@ -7,8 +7,7 @@
 #import <UIKit/UIKit.h>
 #import "H264VTDecode.h"
 #import "DJIVideoHelper.h"
-#import "VideoPreviewer.h"
-#import "VideoPreviewerMacros.h"
+#import "VideoPreviewerLogging.h"
 
 #define DEFAULT_STREAM_FPS (30)
 #define FRAME_MAX_SLICE_COUNT (30)

--- a/Sample Code/VideoPreviewer/VideoPreviewer/MovieGLView.m
+++ b/Sample Code/VideoPreviewer/VideoPreviewer/MovieGLView.m
@@ -25,13 +25,12 @@
 #include <pthread.h>
 
 // SDK
+#import "VideoPreviewer.h"
 #import "VideoPreviewerMacros.h"
 
 #define THUMBNAIL_IMAGE_WIDTH (320)
 #define THUMBNAIL_IMAGE_HIGHT (180)
 
-#define INFO(fmt, ...) //DJILog(@"[GLView]"fmt, ##__VA_ARGS__)
-#define ERROR(fmt, ...) //DJILog(@"[GLView]"fmt, ##__VA_ARGS__)
 //////////////////////////////////////////////////////////
 
 #pragma mark - shaders
@@ -515,7 +514,7 @@ NSString *const renderToScreenFS = SHADER_STRING
     //update frame
     if (frame){
         if(frame->width > 2000 || frame->height > 2000){
-            ERROR(@"size error %f %f", frame->width, frame->height);
+            ERROR(@"size error %d %d", frame->width, frame->height);
             [self.renderLock unlock];
             return;
         }

--- a/Sample Code/VideoPreviewer/VideoPreviewer/MovieGLView.m
+++ b/Sample Code/VideoPreviewer/VideoPreviewer/MovieGLView.m
@@ -25,7 +25,7 @@
 #include <pthread.h>
 
 // SDK
-#import "VideoPreviewer.h"
+#import "VideoPreviewerLogging.h"
 #import "VideoPreviewerMacros.h"
 
 #define THUMBNAIL_IMAGE_WIDTH (320)

--- a/Sample Code/VideoPreviewer/VideoPreviewer/VideoPreviewer.h
+++ b/Sample Code/VideoPreviewer/VideoPreviewer/VideoPreviewer.h
@@ -72,17 +72,24 @@ typedef NS_ENUM(NSUInteger, VideoPreviewerType){
 /*
  * create a new preview, this instance is not the default one
  */
--(instancetype) init;
+-(instancetype _Nonnull ) init;
+-(instancetype _Nonnull ) initWithQueueSize:(int)queueSize;
 
 /**
  *  Push video data
  */
--(void) push:(uint8_t*)videoData length:(int)len;
+-(void) push:(uint8_t*_Nonnull)videoData length:(int)len;
 
 /**
  *  Clear video data buffer
  */
 -(void) clearVideoData;
+
+/** Logging */
+typedef void (^ _Nullable LogFunc)(NSString * _Nonnull fmt);
+@property (class, strong) LogFunc debugLog;
+@property (class, strong) LogFunc infoLog;
+@property (class, strong) LogFunc errorLog;
 
 @end
 
@@ -98,7 +105,7 @@ typedef NS_ENUM(NSUInteger, VideoPreviewerType){
 /**
  *  get default previewer
  */
-+(VideoPreviewer*) instance;
++(VideoPreviewer*_Nullable) instance;
 
 // SDK
 /**
@@ -119,7 +126,7 @@ typedef NS_ENUM(NSUInteger, VideoPreviewerType){
 /*
  * for internal use only
  */
-@property (nonatomic, readonly) MovieGLView* internalGLView;
+@property (nonatomic, readonly) MovieGLView* _Nullable internalGLView;
 @end
 
 @interface VideoPreviewer ()
@@ -150,7 +157,7 @@ typedef NS_ENUM(NSUInteger, VideoPreviewerType){
  *
  *  @return `YES` if it is set successfully.
  */
-- (BOOL)setView:(UIView *)view;
+- (BOOL)setView:(UIView *_Nullable)view;
 
 /**
  *  Unset the view which is set previously.
@@ -169,7 +176,7 @@ typedef NS_ENUM(NSUInteger, VideoPreviewerType){
  *  @param view the instance of the UIView.
  *  @return the location of point in the video stream coordinate
  */
--(CGPoint) convertPoint:(CGPoint)point toVideoViewFromView:(UIView*)view;
+-(CGPoint) convertPoint:(CGPoint)point toVideoViewFromView:(UIView*_Nullable)view;
 
 /**
  *  Convert a point on from the video stream coordinate to the coordinate system
@@ -179,7 +186,7 @@ typedef NS_ENUM(NSUInteger, VideoPreviewerType){
  *  @param view the instance of the UIView.
  *  @return the location of point in the UIView
  */
--(CGPoint) convertPoint:(CGPoint)point fromVideoViewToView:(UIView *)view;
+-(CGPoint) convertPoint:(CGPoint)point fromVideoViewToView:(UIView *_Nullable)view;
 
 @end
 
@@ -277,12 +284,12 @@ typedef NS_ENUM(NSUInteger, VideoPreviewerType){
 /**
  *  Screen capture of the current view
  */
--(void) snapshotPreview:(void(^)(UIImage* snapshot))block;
+-(void) snapshotPreview:(void(^_Nullable)(UIImage* _Nullable snapshot))block;
 
 /**
  *  Screen capture thumbnail
  */
--(void) snapshotThumnnail:(void(^)(UIImage* snapshot))block;
+-(void) snapshotThumnnail:(void(^_Nullable)(UIImage* _Nullable snapshot))block;
 
 @end
 
@@ -293,22 +300,22 @@ typedef NS_ENUM(NSUInteger, VideoPreviewerType){
 /**
  *  @param processor Processor registered to receive the H264 stream data.
  */
--(void) registStreamProcessor:(id<VideoStreamProcessor>)processor;
+-(void) registStreamProcessor:(id<VideoStreamProcessor> _Nullable )processor;
 
 /**
  *  @param processor Remove registered processor list.
  */
--(void) unregistStreamProcessor:(id)processor;
+-(void) unregistStreamProcessor:(id _Nullable )processor;
 
 /*
  *  @param processor Processor registered to receive the VideoFrameYUV frame data.
  */
--(void) registFrameProcessor:(id<VideoFrameProcessor>)processor;
+-(void) registFrameProcessor:(id <VideoFrameProcessor> _Nullable )processor;
 
 /**
  *  @param processor Remove registered processor list.
  */
--(void) unregistFrameProcessor:(id)processor;
+-(void) unregistFrameProcessor:(id _Nullable )processor;
 
 @end
 
@@ -364,7 +371,7 @@ typedef NS_ENUM(NSUInteger, VideoPreviewerType){
 @property(readwrite, nonatomic) CGFloat highlightsDecrease;
 
 // -----------------------Cape added-----------------------
-@property(weak, nonatomic) id<DecompressedFrameDelegate> delegate;
+@property(weak, nonatomic) id <DecompressedFrameDelegate> _Nullable delegate;
 // -----------------------Cape added-----------------------
 
 @end
@@ -374,5 +381,6 @@ typedef NS_ENUM(NSUInteger, VideoPreviewerType){
 ///////////////// delay the decode and smooth config ///////////////////////////
 
 @interface VideoPreviewer ()
-@property (nonatomic, strong) id<DJISmoothDecodeProtocol> smoothDecode;
+@property (nonatomic, strong) id <DJISmoothDecodeProtocol> _Nullable smoothDecode;
 @end
+

--- a/Sample Code/VideoPreviewer/VideoPreviewer/VideoPreviewer.h
+++ b/Sample Code/VideoPreviewer/VideoPreviewer/VideoPreviewer.h
@@ -19,6 +19,8 @@
 #import "DJIRTPlayerRenderView.h"
 #import "DJIVTH264DecoderIFrameData.h"
 
+#import "VideoPreviewerLogging.h"
+
 #define __WAIT_STEP_FRAME__   (0) //单步调试用，搭配test_queue_pull
 
 #define VIDEO_PREVIEWER_DISPATCH "video_preview_create_thread_dispatcher"
@@ -72,24 +74,18 @@ typedef NS_ENUM(NSUInteger, VideoPreviewerType){
 /*
  * create a new preview, this instance is not the default one
  */
--(instancetype _Nonnull ) init;
--(instancetype _Nonnull ) initWithQueueSize:(int)queueSize;
+-(instancetype) init;
+-(instancetype) initWithQueueSize:(int)queueSize;
 
 /**
  *  Push video data
  */
--(void) push:(uint8_t*_Nonnull)videoData length:(int)len;
+-(void) push:(uint8_t*)videoData length:(int)len;
 
 /**
  *  Clear video data buffer
  */
 -(void) clearVideoData;
-
-/** Logging */
-typedef void (^ _Nullable LogFunc)(NSString * _Nonnull fmt);
-@property (class, strong) LogFunc debugLog;
-@property (class, strong) LogFunc infoLog;
-@property (class, strong) LogFunc errorLog;
 
 @end
 
@@ -105,7 +101,7 @@ typedef void (^ _Nullable LogFunc)(NSString * _Nonnull fmt);
 /**
  *  get default previewer
  */
-+(VideoPreviewer*_Nullable) instance;
++(VideoPreviewer*) instance;
 
 // SDK
 /**
@@ -126,7 +122,7 @@ typedef void (^ _Nullable LogFunc)(NSString * _Nonnull fmt);
 /*
  * for internal use only
  */
-@property (nonatomic, readonly) MovieGLView* _Nullable internalGLView;
+@property (nonatomic, readonly) MovieGLView* internalGLView;
 @end
 
 @interface VideoPreviewer ()
@@ -157,7 +153,7 @@ typedef void (^ _Nullable LogFunc)(NSString * _Nonnull fmt);
  *
  *  @return `YES` if it is set successfully.
  */
-- (BOOL)setView:(UIView *_Nullable)view;
+- (BOOL)setView:(UIView *)view;
 
 /**
  *  Unset the view which is set previously.
@@ -176,7 +172,7 @@ typedef void (^ _Nullable LogFunc)(NSString * _Nonnull fmt);
  *  @param view the instance of the UIView.
  *  @return the location of point in the video stream coordinate
  */
--(CGPoint) convertPoint:(CGPoint)point toVideoViewFromView:(UIView*_Nullable)view;
+-(CGPoint) convertPoint:(CGPoint)point toVideoViewFromView:(UIView*)view;
 
 /**
  *  Convert a point on from the video stream coordinate to the coordinate system
@@ -186,7 +182,7 @@ typedef void (^ _Nullable LogFunc)(NSString * _Nonnull fmt);
  *  @param view the instance of the UIView.
  *  @return the location of point in the UIView
  */
--(CGPoint) convertPoint:(CGPoint)point fromVideoViewToView:(UIView *_Nullable)view;
+-(CGPoint) convertPoint:(CGPoint)point fromVideoViewToView:(UIView *)view;
 
 @end
 
@@ -284,12 +280,12 @@ typedef void (^ _Nullable LogFunc)(NSString * _Nonnull fmt);
 /**
  *  Screen capture of the current view
  */
--(void) snapshotPreview:(void(^_Nullable)(UIImage* _Nullable snapshot))block;
+-(void) snapshotPreview:(void(^)(UIImage* snapshot))block;
 
 /**
  *  Screen capture thumbnail
  */
--(void) snapshotThumnnail:(void(^_Nullable)(UIImage* _Nullable snapshot))block;
+-(void) snapshotThumnnail:(void(^)(UIImage* snapshot))block;
 
 @end
 
@@ -300,22 +296,22 @@ typedef void (^ _Nullable LogFunc)(NSString * _Nonnull fmt);
 /**
  *  @param processor Processor registered to receive the H264 stream data.
  */
--(void) registStreamProcessor:(id<VideoStreamProcessor> _Nullable )processor;
+-(void) registStreamProcessor:(id<VideoStreamProcessor>)processor;
 
 /**
  *  @param processor Remove registered processor list.
  */
--(void) unregistStreamProcessor:(id _Nullable )processor;
+-(void) unregistStreamProcessor:(id)processor;
 
 /*
  *  @param processor Processor registered to receive the VideoFrameYUV frame data.
  */
--(void) registFrameProcessor:(id <VideoFrameProcessor> _Nullable )processor;
+-(void) registFrameProcessor:(id<VideoFrameProcessor>)processor;
 
 /**
  *  @param processor Remove registered processor list.
  */
--(void) unregistFrameProcessor:(id _Nullable )processor;
+-(void) unregistFrameProcessor:(id)processor;
 
 @end
 
@@ -371,7 +367,7 @@ typedef void (^ _Nullable LogFunc)(NSString * _Nonnull fmt);
 @property(readwrite, nonatomic) CGFloat highlightsDecrease;
 
 // -----------------------Cape added-----------------------
-@property(weak, nonatomic) id <DecompressedFrameDelegate> _Nullable delegate;
+@property(weak, nonatomic) id<DecompressedFrameDelegate> delegate;
 // -----------------------Cape added-----------------------
 
 @end
@@ -381,6 +377,5 @@ typedef void (^ _Nullable LogFunc)(NSString * _Nonnull fmt);
 ///////////////// delay the decode and smooth config ///////////////////////////
 
 @interface VideoPreviewer ()
-@property (nonatomic, strong) id <DJISmoothDecodeProtocol> _Nullable smoothDecode;
+@property (nonatomic, strong) id<DJISmoothDecodeProtocol> smoothDecode;
 @end
-

--- a/Sample Code/VideoPreviewer/VideoPreviewer/VideoPreviewer.m
+++ b/Sample Code/VideoPreviewer/VideoPreviewer/VideoPreviewer.m
@@ -136,7 +136,13 @@ LB2AUDRemoveParserDelegate>{
 
 @implementation VideoPreviewer
 
+
 -(id)init
+{
+    return [self initWithQueueSize:100];
+}
+
+-(id)initWithQueueSize:(int)queueSize
 {
     self= [super init];
 
@@ -150,7 +156,8 @@ LB2AUDRemoveParserDelegate>{
     _decoderStatus         = VideoDecoderStatus_Normal;
 
     // SDK Changes
-    _dataQueue             = [[VideoPreviewerQueue alloc] initWithSize:100];
+    DJILOG(@"init with queue size %d", queueSize);
+    _dataQueue             = [[VideoPreviewerQueue alloc] initWithSize:queueSize];
 
     _stream_processor_list = [[NSMutableArray alloc] init];
     _frame_processor_list  = [[NSMutableArray alloc] init];
@@ -268,6 +275,17 @@ static VideoPreviewer* previewer = nil;
     }
 }
 
+static LogFunc _debugLog;
++ (LogFunc) debugLog { return _debugLog; }
++ (void)setDebugLog:(LogFunc)newFunc { _debugLog = newFunc;}
+static LogFunc _infoLog;
++ (LogFunc) infoLog { return _infoLog; }
++ (void)setInfoLog:(LogFunc)newFunc { _infoLog = newFunc; }
+static LogFunc _errorLog;
++ (LogFunc) errorLog { return _errorLog; }
++ (void)setErrorLog:(LogFunc)newFunc { _errorLog = newFunc; }
+
+
 -(void) push:(uint8_t*)videoData length:(int)len
 {
 #if __TEST_VIDEO_DELAY__
@@ -313,7 +331,7 @@ static VideoPreviewer* previewer = nil;
                 }
 
                 if (self.dataQueue.count > FRAME_DROP_THRESHOLD) {
-                    DJILOG(@"decode dataqueue drop %d", FRAME_DROP_THRESHOLD);
+                    INFO(@"decode dataqueue drop %d", FRAME_DROP_THRESHOLD);
                     [self.dataQueue clear];
                     [self.smoothDecode resetSmooth];
                 }
@@ -1103,7 +1121,7 @@ static VideoPreviewer* previewer = nil;
         }
 
         if (self.dataQueue.count > FRAME_DROP_THRESHOLD) {
-            DJILOG(@"decode dataqueue drop %d", FRAME_DROP_THRESHOLD);
+            INFO(@"decode dataqueue drop %d", FRAME_DROP_THRESHOLD);
             [self.smoothDecode resetSmooth];
             [self.dataQueue clear];
         }

--- a/Sample Code/VideoPreviewer/VideoPreviewer/VideoPreviewer.m
+++ b/Sample Code/VideoPreviewer/VideoPreviewer/VideoPreviewer.m
@@ -19,6 +19,8 @@
 
 //SDK
 #import "VideoPreviewerMacros.h"
+#import "VideoPreviewerLogging.h"
+
 #include <libavutil/log.h>
 
 #define __TEST_VIDEO_DELAY__  (0)
@@ -274,17 +276,6 @@ static VideoPreviewer* previewer = nil;
         previewer = nil;
     }
 }
-
-static LogFunc _debugLog;
-+ (LogFunc) debugLog { return _debugLog; }
-+ (void)setDebugLog:(LogFunc)newFunc { _debugLog = newFunc;}
-static LogFunc _infoLog;
-+ (LogFunc) infoLog { return _infoLog; }
-+ (void)setInfoLog:(LogFunc)newFunc { _infoLog = newFunc; }
-static LogFunc _errorLog;
-+ (LogFunc) errorLog { return _errorLog; }
-+ (void)setErrorLog:(LogFunc)newFunc { _errorLog = newFunc; }
-
 
 -(void) push:(uint8_t*)videoData length:(int)len
 {

--- a/Sample Code/VideoPreviewer/VideoPreviewer/VideoPreviewer.m
+++ b/Sample Code/VideoPreviewer/VideoPreviewer/VideoPreviewer.m
@@ -321,8 +321,8 @@ static VideoPreviewer* previewer = nil;
                     return;
                 }
 
-                if (self.dataQueue.count > FRAME_DROP_THRESHOLD) {
-                    INFO(@"decode dataqueue drop %d", FRAME_DROP_THRESHOLD);
+                if (self.dataQueue.count > FRAME_DROP_THRESHOLD * self.dataQueue.size / 100) {
+                    INFO(@"decode dataqueue drop %d", FRAME_DROP_THRESHOLD * self.dataQueue.size / 100);
                     [self.dataQueue clear];
                     [self.smoothDecode resetSmooth];
                 }
@@ -1111,8 +1111,8 @@ static VideoPreviewer* previewer = nil;
             return;
         }
 
-        if (self.dataQueue.count > FRAME_DROP_THRESHOLD) {
-            INFO(@"decode dataqueue drop %d", FRAME_DROP_THRESHOLD);
+        if (self.dataQueue.count > FRAME_DROP_THRESHOLD * self.dataQueue.size / 100) {
+            INFO(@"decode dataqueue drop %d", FRAME_DROP_THRESHOLD * self.dataQueue.size / 100);
             [self.smoothDecode resetSmooth];
             [self.dataQueue clear];
         }

--- a/Sample Code/VideoPreviewer/VideoPreviewer/VideoPreviewerLogging.h
+++ b/Sample Code/VideoPreviewer/VideoPreviewer/VideoPreviewerLogging.h
@@ -1,0 +1,28 @@
+//
+//  VideoPreviewerLogging.h
+//  VideoPreviewer
+//
+//  Created by Rick Pasetto on 1/25/18.
+//  Copyright © 2018 dji. All rights reserved.
+//
+
+#ifndef VideoPreviewerLogging_h
+#define VideoPreviewerLogging_h
+
+#define DEBUGLOG(string) if(VideoPreviewerLogging.debugLog){VideoPreviewerLogging.debugLog(string);}
+#define INFOLOG(string) if(VideoPreviewerLogging.infoLog){VideoPreviewerLogging.infoLog(string);}
+#define ERRORLOG(string) if(VideoPreviewerLogging.errorLog){VideoPreviewerLogging.errorLog(string);}
+
+#define STRINGIFY(fmt, ...) [NSString stringWithFormat:fmt, ##__VA_ARGS__]
+#define DJILOG(fmt, ...)  DEBUGLOG(STRINGIFY(fmt, ##__VA_ARGS__))
+#define INFO(fmt, ...)  INFOLOG(STRINGIFY(fmt, ##__VA_ARGS__))
+#define ERROR(fmt, ...)  ERRORLOG(STRINGIFY(fmt, ##__VA_ARGS__))
+
+@interface VideoPreviewerLogging : NSObject
+typedef void (^ _Nullable LogFunc)(NSString * _Nonnull fmt);
+@property (class, strong) LogFunc debugLog;
+@property (class, strong) LogFunc infoLog;
+@property (class, strong) LogFunc errorLog;
+@end
+
+#endif /* VideoPreviewerLogging_h */

--- a/Sample Code/VideoPreviewer/VideoPreviewer/VideoPreviewerLogging.m
+++ b/Sample Code/VideoPreviewer/VideoPreviewer/VideoPreviewerLogging.m
@@ -1,0 +1,25 @@
+//
+//  VideoPreviewerLogging.m
+//  VideoPreviewer
+//
+//  Created by Rick Pasetto on 1/25/18.
+//  Copyright © 2018 dji. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "VideoPreviewerLogging.h"
+
+@implementation VideoPreviewerLogging
+
+static LogFunc _debugLog;
++ (LogFunc) debugLog { return _debugLog; }
++ (void)setDebugLog:(LogFunc)newFunc { _debugLog = newFunc;}
+static LogFunc _infoLog;
++ (LogFunc) infoLog { return _infoLog; }
++ (void)setInfoLog:(LogFunc)newFunc { _infoLog = newFunc; }
+static LogFunc _errorLog;
++ (LogFunc) errorLog { return _errorLog; }
++ (void)setErrorLog:(LogFunc)newFunc { _errorLog = newFunc; }
+
+@end
+

--- a/Sample Code/VideoPreviewer/VideoPreviewer/VideoPreviewerMacros.h
+++ b/Sample Code/VideoPreviewer/VideoPreviewer/VideoPreviewerMacros.h
@@ -23,6 +23,13 @@ if(__strong##__TARGET__==nil)return;
 
 #define SAFE_BLOCK(block, ...) if(block){block(__VA_ARGS__);}
 
-#define DJILOG(fmt, ...)
+#define DEBUGLOG(string) if(VideoPreviewer.debugLog){VideoPreviewer.debugLog(string);}
+#define INFOLOG(string) if(VideoPreviewer.infoLog){VideoPreviewer.infoLog(string);}
+#define ERRORLOG(string) if(VideoPreviewer.errorLog){VideoPreviewer.errorLog(string);}
+
+#define STRINGIFY(fmt, ...) [NSString stringWithFormat:fmt, ##__VA_ARGS__]
+#define DJILOG(fmt, ...)  DEBUGLOG(STRINGIFY(fmt, ##__VA_ARGS__))
+#define INFO(fmt, ...)  INFOLOG(STRINGIFY(fmt, ##__VA_ARGS__))
+#define ERROR(fmt, ...)  ERRORLOG(STRINGIFY(fmt, ##__VA_ARGS__))
 
 #endif /* VideoPreviewerMacros_h */

--- a/Sample Code/VideoPreviewer/VideoPreviewer/VideoPreviewerMacros.h
+++ b/Sample Code/VideoPreviewer/VideoPreviewer/VideoPreviewerMacros.h
@@ -23,13 +23,4 @@ if(__strong##__TARGET__==nil)return;
 
 #define SAFE_BLOCK(block, ...) if(block){block(__VA_ARGS__);}
 
-#define DEBUGLOG(string) if(VideoPreviewer.debugLog){VideoPreviewer.debugLog(string);}
-#define INFOLOG(string) if(VideoPreviewer.infoLog){VideoPreviewer.infoLog(string);}
-#define ERRORLOG(string) if(VideoPreviewer.errorLog){VideoPreviewer.errorLog(string);}
-
-#define STRINGIFY(fmt, ...) [NSString stringWithFormat:fmt, ##__VA_ARGS__]
-#define DJILOG(fmt, ...)  DEBUGLOG(STRINGIFY(fmt, ##__VA_ARGS__))
-#define INFO(fmt, ...)  INFOLOG(STRINGIFY(fmt, ##__VA_ARGS__))
-#define ERROR(fmt, ...)  ERRORLOG(STRINGIFY(fmt, ##__VA_ARGS__))
-
 #endif /* VideoPreviewerMacros_h */


### PR DESCRIPTION
VideoPreviewer does a bunch of logging (some interesting, like dropped frames).  This adds the ability to set log function hooks so we can see them (e.g. in Loggly)

BONUS: Adds ability to set frame queue size so we can limit frame lag.