### PR TITLE
Cape hack for DJISDK 4.7

### DIFF
--- a/Sample Code/DJIWidget/DJIWidget/VideoPreviewer/DJICustomVideoFrameExtractor.h
+++ b/Sample Code/DJIWidget/DJIWidget/VideoPreviewer/DJICustomVideoFrameExtractor.h
@@ -93,4 +93,6 @@
  */
 -(uint32_t) popNextFrameUUID;
 
+-(CVPixelBufferRef)getCVImage;
+
 @end

--- a/Sample Code/DJIWidget/DJIWidget/VideoPreviewer/DJISoftwareDecodeProcessor.h
+++ b/Sample Code/DJIWidget/DJIWidget/VideoPreviewer/DJISoftwareDecodeProcessor.h
@@ -11,6 +11,7 @@
 @interface DJISoftwareDecodeProcessor : NSObject <VideoStreamProcessor>
 @property (nonatomic, weak) id<VideoFrameProcessor> frameProcessor;
 @property (nonatomic, assign) BOOL enabled;
+@property (nonatomic, weak) id<DecompressedFrameDelegate> delegate;
 
 -(id) initWithExtractor:(DJICustomVideoFrameExtractor*)extractor;
 @end

--- a/Sample Code/DJIWidget/DJIWidget/VideoPreviewer/DJISoftwareDecodeProcessor.m
+++ b/Sample Code/DJIWidget/DJIWidget/VideoPreviewer/DJISoftwareDecodeProcessor.m
@@ -71,6 +71,15 @@
             
             _decodeFrameIndex = (++_decodeFrameIndex)%RENDER_FRAME_NUMBER;
             
+            // -----------------------Cape added-----------------------
+            if (self.delegate) {
+                CVImageBufferRef image = [weakself.extractor getCVImage];
+                if (image) {
+                    [self.delegate didReceiveDecompressedFrame:image];
+                    CFRelease(image);
+                }
+            }
+            // --------------------------------------------------------
         }
         else{
             decodeSuccess = NO;

--- a/Sample Code/DJIWidget/DJIWidget/VideoPreviewer/DJIStreamCommon.h
+++ b/Sample Code/DJIWidget/DJIWidget/VideoPreviewer/DJIStreamCommon.h
@@ -223,3 +223,8 @@ typedef NS_ENUM(NSUInteger, VideoPresentContentMode){
  */
 -(void) videoProcessFailedFrame:(VideoFrameH264Raw*)frame;
 @end
+
+@protocol DecompressedFrameDelegate <NSObject>
+@required
+- (void)didReceiveDecompressedFrame:(CVImageBufferRef)image;
+@end

--- a/Sample Code/DJIWidget/DJIWidget/VideoPreviewer/DJIVideoPreviewer.h
+++ b/Sample Code/DJIWidget/DJIWidget/VideoPreviewer/DJIVideoPreviewer.h
@@ -420,6 +420,10 @@ typedef NS_ENUM(NSUInteger, DJIVideoPreviewerType){
  */
 @property(readwrite, nonatomic) CGFloat highlightsDecrease;
 
+// -----------------------Cape added-----------------------
+@property(weak, nonatomic) id<DecompressedFrameDelegate> delegate;
+// -----------------------Cape added-----------------------
+
 @end
 
 

--- a/Sample Code/DJIWidget/DJIWidget/VideoPreviewer/DJIVideoPreviewer.m
+++ b/Sample Code/DJIWidget/DJIWidget/VideoPreviewer/DJIVideoPreviewer.m
@@ -1599,6 +1599,10 @@ static DJIVideoPreviewer* previewer = nil;
                 return;
             }
             
+            // -----------------------Cape added-----------------------
+            [self.delegate didReceiveDecompressedFrame:image];
+            // --------------------------------------------------------
+
             VideoFrameYUV yuvImage = {0};
             yuvImage.luma = CVPixelBufferGetBaseAddressOfPlane(image, 0);
             yuvImage.chromaB = CVPixelBufferGetBaseAddressOfPlane(image, 1);
@@ -1642,6 +1646,11 @@ static DJIVideoPreviewer* previewer = nil;
                      return;
                  }
                  
+                 // -----------------------Cape added-----------------------
+                 // FIXME: Causes crash in webRTC with XT. Works with X3 but super janky video.
+                 [self.delegate didReceiveDecompressedFrame:image];
+                 // --------------------------------------------------------
+
                  VideoFrameYUV yuvImage = {0};
                  yuvImage.luma = CVPixelBufferGetBaseAddressOfPlane(image, 0);
                  yuvImage.chromaB = CVPixelBufferGetBaseAddressOfPlane(image, 1);
@@ -1963,5 +1972,13 @@ static NSThread* g_pack_pull_test_thread;
         }
     }
 }
+
+// -----------------------Cape added-----------------------
+-(void) setDelegate:(id<DecompressedFrameDelegate>)delegate
+{
+    _delegate = delegate;
+    self.soft_decoder.delegate = delegate;
+}
+// --------------------------------------------------------
 
 @end

--- a/Sample Code/ObjcSampleCode/DJISdkDemo/Demo/DemoUtility/DemoUtility.h
+++ b/Sample Code/ObjcSampleCode/DJISdkDemo/Demo/DemoUtility/DemoUtility.h
@@ -12,14 +12,14 @@
 
 #import "DemoUtilityMacro.h"
 #import "DemoUtilityMethod.h"
-#import "DemoAlertView.h"
+//#import "DemoAlertView.h"
 #import "DemoComponentHelper.h"
-#import "DemoGetSetViewController.h"
-#import "DemoPushInfoViewController.h"
-#import "DemoSettingItem.h"
-#import "DemoTableViewController.h"
-#import "MBProgressHUD.h"
-#import "DemoScrollView.h"
+//#import "DemoGetSetViewController.h"
+//#import "DemoPushInfoViewController.h"
+//#import "DemoSettingItem.h"
+//#import "DemoTableViewController.h"
+//#import "MBProgressHUD.h"
+//#import "DemoScrollView.h"
 #import "DemoXT2Helper.h"
 
 #endif /* DemoUtility_h */

--- a/Sample Code/ObjcSampleCode/DJISdkDemo/VideoPreviewerAdapter/VideoPreviewerSDKAdapter.h
+++ b/Sample Code/ObjcSampleCode/DJISdkDemo/VideoPreviewerAdapter/VideoPreviewerSDKAdapter.h
@@ -30,4 +30,8 @@
 // For Mavic 2
 -(void)setupFrameControlHandler;
 
+// ------------- Cape added ---------------------------
+-(void)setIsForLightbridge2;
+// ----------------------------------------------------
+
 @end

--- a/Sample Code/ObjcSampleCode/DJISdkDemo/VideoPreviewerAdapter/VideoPreviewerSDKAdapter.m
+++ b/Sample Code/ObjcSampleCode/DJISdkDemo/VideoPreviewerAdapter/VideoPreviewerSDKAdapter.m
@@ -96,6 +96,10 @@ const static NSTimeInterval REFRESH_INTERVAL = 1.0;
     }
 }
 
+// ------------- Cape added ---------------------------
+-(void)setIsForLightbridge2 { self.isForLightbridge2 = true; }
+// ----------------------------------------------------
+
 -(void)startRefreshTimer {
     dispatch_async(dispatch_get_main_queue(), ^{
         if (!self.refreshTimer) {


### PR DESCRIPTION
We've been maintaining our version of Mobile-SDK-iOS as `cape-master` but merging new SDK on top of it was total mess and didn't work cleanly. So,I decided to make a clean branch based on the latest 4.7, and this is the minimum changes.

This PR will be merged to `cape-47` branch and merged to DT app via Submodule (which I've already tested with P4 and Inspire 1, both software decoder and hardware decoder).